### PR TITLE
ci: create releases via semantic-release

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,5 @@
+# Always validate the PR title AND all the commits
+titleAndCommits: true
+# Allows use of Merge commits (eg on github: "Merge branch 'master' into feature/ride-unicorns")
+# this is only relevant when using commitsOnly: true (or titleAndCommits: true)
+allowMergeCommits: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,15 @@
-name: Test
+name: CI
 
 permissions: {}
 
 on:
-  push:
   pull_request:
+  push:
+    branches:
+      - alpha
+      - beta
+      - main
+      - renovate/**
 
 jobs:
   ci-optimization:
@@ -38,3 +43,14 @@ jobs:
     - name: Test
       run: |
         pnpm test
+  release_semantic:
+    needs: test
+    name: Release (semantic)
+    uses: dargmuesli/github-actions/.github/workflows/release-semantic.yml@e9c9cf391baeb261cf62c0af6c4af2245bae0662 # 5.9.2
+    permissions:
+      contents: write
+      id-token: write
+    secrets:
+      GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
+    with:
+      GH_APP_ID: ${{ vars.GH_APP_ID }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,0 +1,22 @@
+{
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {}
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {}
+      }
+    ],
+    "@semantic-release/changelog",
+    "@semantic-release/github",
+    "@semantic-release/git"
+  ],
+  "tagFormat": "${version}"
+}


### PR DESCRIPTION
Adds a semantic-release based release pipeline, adapted from the reusable workflow already used across other dargmuesli repos (`github-actions`, `commitlint-config`, `jonas-thelemann`).

- Renames `.github/workflows/test.yml` to `ci.yml` and adds a `release_semantic` job using `dargmuesli/github-actions/.github/workflows/release-semantic.yml`
- Adds `.releaserc.json` (commit-analyzer, release-notes-generator, changelog, github, git plugins, no npm publish step, since this preset is consumed via `github>dargmuesli/renovate-config`, not npm)
- Adds `.github/semantic.yml` for PR title/commit validation via the Semantic Pull Requests app

Closes #52.