### PR TITLE
feat(docker-compose)!: use renovate default file patterns

### DIFF
--- a/default.json
+++ b/default.json
@@ -51,11 +51,6 @@
       "registryUrlTemplate": "https://{{#if (equals distro 'ubuntu')}}security.ubuntu.com/ubuntu{{else}}security.debian.org/debian-security{{/if}}?suite={{suite}}-security&components=main,{{#if (equals distro 'ubuntu')}}multiverse,restricted,universe{{else}}contrib,non-free{{/if}}&binaryArch=amd64"
     }
   ],
-  "docker-compose": {
-    "managerFilePatterns": [
-      "/^src/(development/stack|production/production)\\.ya?ml$/"
-    ]
-  },
   "extends": [
     "config:best-practices",
     "group:allNonMajor",


### PR DESCRIPTION
Removes the custom `docker-compose.managerFilePatterns` override entirely, falling back to Renovate's own default (`/(^|/)(?:docker-)?compose[^/]*\.ya?ml$/`).

The override was scoped to dargstack v3's non-standard `stack.yml`/`production.yml` filenames. Setting `managerFilePatterns` replaces Renovate's default rather than extending it, so it silently blocked tracking Docker image tags in any `compose.yaml` file, which is exactly what dargstack v4 uses (one file per service under `src/development/<service>/` and `src/production/<service>/`, e.g. maevsi/stack, dargmuesli/jonas-thelemann_stack).